### PR TITLE
Render restructure

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -49,6 +49,8 @@ bool Engine::init() {
     glm::vec2 window_size = window.getDrawableSize();
     state->reshape( (int)window_size.x, (int)window_size.y );
 
+    state->transitionTo();
+
     return true;
 }
 
@@ -65,6 +67,8 @@ void Engine::quitEngine() {
 void Engine::testAndHandleStateChange() {
     GameState *next = state->getNextState();
     if( next != nullptr ) {
+        RenderSystem &rs = RenderSystem::getRenderSystem();
+        rs.clearRenderLists();
         // Test if the current state should be destroyed
         if( state->shouldDestroy() ) {
             delete state;
@@ -72,6 +76,7 @@ void Engine::testAndHandleStateChange() {
 
         // Swap in the new state and perform necessary config
         state = next;
+        state->transitionTo();
         glm::vec2 draw_size = window.getDrawableSize();
         state->reshape( (int)draw_size.x, (int)draw_size.y );
         window.setMouseLock( state->shouldLockMouse() );

--- a/src/Engine/GameObject.hpp
+++ b/src/Engine/GameObject.hpp
@@ -8,9 +8,10 @@ class GameObject;
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/quaternion.hpp>
 
+#include "Systems/Rendering/Renderable.hpp"
 // #include "Systems/Rendering/SkinnedMesh.hpp"
 // #include "Systems/Rendering/OverlayMesh.hpp"
-// #include "Systems/Rendering/Mesh.hpp"
+// #include "Systems/Rendering/Renderable.hpp"
 #include "Systems/Physics/RigidBodyPhysicsComponent.hpp"
 
 class Mesh;
@@ -45,12 +46,9 @@ public:
 
 	std::string getID() const { return identifier; }
 
-	virtual bool hasMesh() const { return false; }
-	virtual Mesh * getMesh() const { return (Mesh *) nullptr; }
-	virtual bool hasSkinnedMesh() const { return false; }
-	virtual SkinnedMesh * getSkinnedMesh() const { return (SkinnedMesh *) nullptr; }
-	virtual bool hasOverlayMesh() const { return false; }
-	virtual OverlayMesh * getOverlayMesh() const { return (OverlayMesh *) nullptr; }
+	virtual bool hasRenderable() const { return false; }
+	virtual Renderable * getRenderable() const { return (Renderable *) nullptr; }
+
 	virtual bool hasPhysicsComponent() const { return false; }
 	virtual RigidBodyPhysicsComponent * getPhysicsComponent() const { return nullptr; }
 

--- a/src/Engine/GameObjects/DynamicCube.hpp
+++ b/src/Engine/GameObjects/DynamicCube.hpp
@@ -16,8 +16,8 @@ public:
     DynamicCube( float scale );
     ~DynamicCube();
 
-    inline bool hasMesh() const override { return true; }
-    inline Mesh * getMesh() const override { return mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) mesh; }
     inline bool hasPhysicsComponent() const override { return physics != nullptr; }
     inline RigidBodyPhysicsComponent * getPhysicsComponent() const override { return physics; }
 

--- a/src/Engine/GameObjects/MenuButton.hpp
+++ b/src/Engine/GameObjects/MenuButton.hpp
@@ -22,8 +22,8 @@ public:
     MenuButton(std::string id, float xinput, float yinput, float winput, float hinput, std::string material_name);
     ~MenuButton();
 
-    bool hasOverlayMesh() const override { return true; }
-    OverlayMesh * getOverlayMesh() const override { return mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) mesh; }
 
     bool clickTest(float xinput, float yinput);
 };

--- a/src/Engine/GameObjects/Obstacle.hpp
+++ b/src/Engine/GameObjects/Obstacle.hpp
@@ -14,8 +14,8 @@ public:
     Obstacle( std::string id, Mesh *mesh_in, RigidBodyPhysicsComponent *physics_in );
     ~Obstacle();
 
-    bool hasMesh() const override { return true; }
-    Mesh * getMesh() const override { return mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) mesh; }
     bool hasPhysicsComponent() const override { return physics != nullptr; }
     RigidBodyPhysicsComponent * getPhysicsComponent() const override { return physics; }
 

--- a/src/Engine/GameObjects/Player.hpp
+++ b/src/Engine/GameObjects/Player.hpp
@@ -18,8 +18,8 @@ public:
     Player(std::string identifier, SkinnedMesh * skinned_mesh_in);
     ~Player();
 
-    inline bool hasSkinnedMesh() const override { return true; }
-	inline SkinnedMesh * getSkinnedMesh() const override { return skinned_mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) skinned_mesh; }
     inline bool hasPhysicsComponent() const override { return true; }
 	inline RigidBodyPhysicsComponent * getPhysicsComponent() const override { return physics; }
 

--- a/src/Engine/GameObjects/SceneRenderable.hpp
+++ b/src/Engine/GameObjects/SceneRenderable.hpp
@@ -12,8 +12,8 @@ public:
     SceneRenderable( std::string id, Mesh *mesh_in );
     ~SceneRenderable();
 
-    bool hasMesh() const { return true; }
-    Mesh * getMesh() const { return mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) mesh; }
 };
 
 #endif

--- a/src/Engine/GameObjects/StaticCubeObstacle.hpp
+++ b/src/Engine/GameObjects/StaticCubeObstacle.hpp
@@ -14,8 +14,8 @@ public:
     StaticCubeObstacle( float scale );
     ~StaticCubeObstacle();
 
-    bool hasMesh() const { return true; }
-    Mesh * getMesh() const { return mesh; }
+    inline bool hasRenderable() const override { return true; }
+    inline Renderable * getRenderable() const override { return (Renderable *) mesh; }
     bool hasPhysicsComponent() const { return physics != nullptr; }
     RigidBodyPhysicsComponent * getPhysicsComponent() const { return physics; }
 

--- a/src/Engine/GameState.hpp
+++ b/src/Engine/GameState.hpp
@@ -87,6 +87,8 @@ public:
         return ret;
     }
 
+    inline void transitionTo() { render_system.populateRenderLists(scene); }
+
     inline bool shouldDestroy() { return should_destroy_on_state_change; }
 
     inline bool getQuitGame() { return quit_game; }

--- a/src/Engine/States/InGameState.cpp
+++ b/src/Engine/States/InGameState.cpp
@@ -155,7 +155,7 @@ void InGameState::gameLoop() {
     camera->createMatrices();
 
     // Render all
-    render_system.render( dt, scene );
+    render_system.render( dt );
 
     if( fell() ){
         glm::vec3 spawnPoint = glm::vec3(0.f,10.f,0.f);

--- a/src/Engine/States/MainMenu.cpp
+++ b/src/Engine/States/MainMenu.cpp
@@ -116,5 +116,5 @@ void MainMenu::gameLoop() {
 
     animation_system->evaluateAnimations(dt);
 
-    render_system.render( 0.f, scene );
+    render_system.render( 0.f );
 }

--- a/src/Engine/States/Menu.cpp
+++ b/src/Engine/States/Menu.cpp
@@ -58,5 +58,5 @@ void Menu::handleMouseButtonUp( SDL_Event e ) {
 }
 
 void Menu::gameLoop() {
-    render_system.render( 0.f, scene );
+    render_system.render( 0.f );
 }

--- a/src/Engine/Systems/Rendering/Mesh.hpp
+++ b/src/Engine/Systems/Rendering/Mesh.hpp
@@ -3,12 +3,13 @@
 
 #include <GL/glew.h>
 
+#include "Renderable.hpp"
 #include "Shader.hpp"
 #include "Material.hpp"
 
 #define N_VERTEX_VALUES 19
 
-class Mesh {
+class Mesh : public Renderable {
 private:
 	GLuint vao, vertex_vao;
 	GLuint vbo;
@@ -20,6 +21,8 @@ public:
 	Mesh(): vao(0), vbo(0), ibo(0), num_vertices(0), material(nullptr) {}
 	Mesh(GLuint vbo_in, GLuint ibo_in, int num_vertices_in);
 	~Mesh();
+
+	inline RenderableType getType() { return RenderableType::MESH; }
 
 	void draw();
 	void drawVerticesOnly();

--- a/src/Engine/Systems/Rendering/OverlayMesh.hpp
+++ b/src/Engine/Systems/Rendering/OverlayMesh.hpp
@@ -3,10 +3,11 @@
 
 #include <GL/glew.h>
 
+#include "Renderable.hpp"
 #include "Shader.hpp"
 #include "Material.hpp"
 
-class OverlayMesh {
+class OverlayMesh : public Renderable {
 private:
     GLuint vao, vbo, ibo;
     int num_vertices;
@@ -16,6 +17,8 @@ public:
 	OverlayMesh(): vao(0), vbo(0), ibo(0), num_vertices(0), material(nullptr) {}
 	OverlayMesh(GLuint vbo_in, GLuint ibo_in, int num_vertices_in);
 	~OverlayMesh();
+
+	inline RenderableType getType() { return RenderableType::OVERLAY; }
 
 	void draw();
 

--- a/src/Engine/Systems/Rendering/RenderSystem.cpp
+++ b/src/Engine/Systems/Rendering/RenderSystem.cpp
@@ -294,14 +294,18 @@ void RenderSystem::addToRenderLists( GameObject * game_object ) {
 		Renderable * game_object_renderable = game_object->getRenderable();
 		RenderableType type = game_object_renderable->getType();
 
-		if(type == RenderableType::MESH) {
-			mesh_list.push_back(game_object);
-		}
-		else if(type == RenderableType::SKINNED_MESH) {
-			skinned_mesh_list.push_back(game_object);
-		}
-		else if(type == RenderableType::OVERLAY) {
-			overlay_mesh_list.push_back(game_object);
+		switch(type) {
+			case RenderableType::MESH:
+				mesh_list.push_back(game_object);
+				break;
+			case RenderableType::SKINNED_MESH:
+				skinned_mesh_list.push_back(game_object);
+				break;
+			case RenderableType::OVERLAY:
+				overlay_mesh_list.push_back(game_object);
+				break;
+			default:
+				break;
 		}
 	}
 }

--- a/src/Engine/Systems/Rendering/RenderSystem.cpp
+++ b/src/Engine/Systems/Rendering/RenderSystem.cpp
@@ -282,6 +282,14 @@ void RenderSystem::render( double dt ) {
 }
 
 void RenderSystem::populateRenderLists( GameObject * game_object ) {
+	addToRenderLists(game_object);
+
+	for(int i = 0; i < game_object->getNumChildren(); i++) {
+		populateRenderLists(game_object->getChild(i));
+	}
+}
+// non recursive
+void RenderSystem::addToRenderLists( GameObject * game_object ) {
 	if(game_object->hasRenderable()) {
 		Renderable * game_object_renderable = game_object->getRenderable();
 		RenderableType type = game_object_renderable->getType();
@@ -296,15 +304,26 @@ void RenderSystem::populateRenderLists( GameObject * game_object ) {
 			overlay_mesh_list.push_back(game_object);
 		}
 	}
-	for(int i = 0; i < game_object->getNumChildren(); i++) {
-		populateRenderLists(game_object->getChild(i));
-	}
 }
 
 void RenderSystem::clearRenderLists() {
 	mesh_list.clear();
 	skinned_mesh_list.clear();
 	overlay_mesh_list.clear();
+}
+
+void RenderSystem::removeGameObjectFromRenderLists(GameObject * game_object) {
+	std::remove(mesh_list.begin(),mesh_list.end(),game_object);
+	std::remove(skinned_mesh_list.begin(),skinned_mesh_list.end(),game_object);
+	std::remove(overlay_mesh_list.begin(),overlay_mesh_list.end(),game_object);
+}
+
+void RenderSystem::removeGameObjectFromRenderListsRecursive(GameObject * game_object) {
+	removeGameObjectFromRenderLists(game_object);
+
+	for(int i = 0; i < game_object->getNumChildren(); i++) {
+		removeGameObjectFromRenderListsRecursive(game_object->getChild(i));
+	}
 }
 
 // Function to create default view and projection matrices only if the camera seg faults

--- a/src/Engine/Systems/Rendering/RenderSystem.hpp
+++ b/src/Engine/Systems/Rendering/RenderSystem.hpp
@@ -10,6 +10,8 @@
 #include <glm/mat4x4.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 
+#include "Renderable.hpp"
+
 #include "ShaderManager.hpp"
 #include "Framebuffer.hpp"
 #include "Mesh.hpp"
@@ -20,6 +22,7 @@
 #include "../../GameObject.hpp"
 #include "../../GameObjects/Camera.hpp"
 #include "../../SettingsManager.hpp"
+
 
 struct Light {
     glm::vec3 location;
@@ -121,9 +124,6 @@ private:
         Rendering pipeline
     **/
 
-    // Set up render lists - iterate through the scenegraph and identify what needs to be drawn
-    void populateRenderLists(GameObject * gameObject);
-
     // Create the necessary matrices for rendering
     void createOrthoMatrices();
 
@@ -152,11 +152,16 @@ private:
 
 public:
 
+    // Set up render lists - iterate through the scenegraph and identify what needs to be drawn
+    void populateRenderLists(GameObject * scenegraph);
+
+    void clearRenderLists();
+
     // Get the singleton instance
     static RenderSystem & getRenderSystem();
 
     // RENDER
-    void render( double dt, GameObject * sceneGraph );
+    void render( double dt );
 
     void reshape( int x_size, int y_size );
 

--- a/src/Engine/Systems/Rendering/RenderSystem.hpp
+++ b/src/Engine/Systems/Rendering/RenderSystem.hpp
@@ -154,8 +154,12 @@ public:
 
     // Set up render lists - iterate through the scenegraph and identify what needs to be drawn
     void populateRenderLists(GameObject * scenegraph);
+    // non recursive - adds single node
+    void addToRenderLists( GameObject * game_object );
 
     void clearRenderLists();
+    void removeGameObjectFromRenderLists( GameObject * game_object );
+    void removeGameObjectFromRenderListsRecursive( GameObject * game_object );
 
     // Get the singleton instance
     static RenderSystem & getRenderSystem();

--- a/src/Engine/Systems/Rendering/Renderable.hpp
+++ b/src/Engine/Systems/Rendering/Renderable.hpp
@@ -1,0 +1,17 @@
+#ifndef RENDERABLE_HPP
+#define RENDERABLE_HPP
+
+enum class RenderableType {
+	NONE,
+	MESH,
+	SKINNED_MESH,
+	OVERLAY,
+	PARTICLE_SYSTEM
+};
+
+class Renderable {
+public:
+	virtual RenderableType getType() = 0;
+};
+
+#endif

--- a/src/Engine/Systems/Rendering/SkinnedMesh.hpp
+++ b/src/Engine/Systems/Rendering/SkinnedMesh.hpp
@@ -3,6 +3,7 @@
 
 #include <GL/glew.h>
 
+#include "Renderable.hpp"
 #include "Shader.hpp"
 #include "Material.hpp"
 #include "./../Animation/Joint.hpp"
@@ -13,7 +14,7 @@
 #define N_INT_ATTRIBUTES 0
 #define N_FLOAT_ATTRIBUTES 41
 
-class SkinnedMesh {
+class SkinnedMesh : public Renderable {
 private:
 	GLuint vao, vertex_vao;
 	GLuint vbo;
@@ -26,6 +27,8 @@ public:
 	SkinnedMesh() {vao=0;vbo=0;ibo=0;num_vertices=0;joints=NULL;}
 	SkinnedMesh(GLuint vbo_in, GLuint ibo_in, int num_vertices_in, JointList * joints_in);
 	~SkinnedMesh();
+
+	inline RenderableType getType() { return RenderableType::SKINNED_MESH; }
 
 	void draw();
 	void drawVerticesOnly();


### PR DESCRIPTION
restructured some of the game object functionality to make adding new types of renderable objects more scalable and made render system's render lists more efficient